### PR TITLE
Service documentation, design decisions and Traefik rate limiting (#10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,18 @@ docker compose -f docker-compose-dev.yaml up
 docker compose up
 ```
 
+## Design Decisions
+
+**CQRS in the order service.** Orders are written to PostgreSQL and simultaneously projected into MongoDB as a read model. The write side owns consistency; the read side is optimised for queries without joins or locking contention. This makes the query path independently scalable and keeps the write path simple.
+
+**Kafka for async communication.** When an order is placed the service publishes an event instead of calling downstream services directly. This keeps services decoupled — a slow or unavailable consumer does not block the order write path, and new consumers can be added without changing the order service.
+
+**Self-hosted OAuth2 Authorization Server.** The user service runs Spring Authorization Server and issues signed JWT access tokens. Other services validate tokens locally using the public key fetched once from the JWK endpoint — no per-request round-trip to the auth server. Two OAuth2 clients are registered: `client_credentials` for service-to-service calls and `authorization_code + PKCE` for the SPA frontend.
+
+**Consul for service discovery.** Each service registers itself in Consul at startup and exposes a health-check endpoint. Consul acts as the central registry, so no service needs to know the address of another at deploy time — they resolve each other by name through the registry.
+
+**Traefik as the API gateway.** Traefik watches Consul and builds its routing table dynamically from the tags each service registers. It handles path-based routing, load balancing across instances, and TLS termination without any static configuration. Adding or removing a service instance requires no change to the gateway.
+
 ## Documentations
 
 - User microservice — [docs](./docs/user-service/README.md)

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ docker compose up
 
 **Traefik as the API gateway.** Traefik watches Consul and builds its routing table dynamically from the tags each service registers. It handles path-based routing, load balancing across instances, and TLS termination without any static configuration. Adding or removing a service instance requires no change to the gateway.
 
+**Rate limiting at the gateway.** Each service route has a token bucket rate limiter defined in Traefik's dynamic config. The bucket refills at a fixed rate and allows short bursts above it — once the bucket is empty, requests get a 429 until it refills. The limit is per client IP and per route, so hitting `/api/v1/products` doesn't affect the budget for `/api/v1/orders`. Note: Traefik has no JWT awareness, so limiting per authenticated user isn't possible at this layer. That would require either implementing it inside each service or using a Redis-backed shared counter keyed by the JWT `sub` claim, which keeps the logic centralised and consistent across all instances.
+
 ## Documentations
 
 - User microservice — [docs](./docs/user-service/README.md)

--- a/eshop-order-service/Dockerfile
+++ b/eshop-order-service/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 
 RUN chmod +x ./gradlew
 
-RUN --mount=type=cache,target=/root/.gradle  ./gradlew build
+RUN --mount=type=cache,target=/root/.gradle  ./gradlew build -x test
 
 FROM amazoncorretto:21-alpine
 

--- a/eshop-order-service/src/main/resources/application-dev.yaml
+++ b/eshop-order-service/src/main/resources/application-dev.yaml
@@ -50,6 +50,7 @@ spring:
           - traefik.enable=true
           - traefik.http.routers.eshop-order-service.rule=PathPrefix(`/api/v1/orders`)
           - traefik.http.services.eshop-order-service.loadbalancer.server.port=8082
+          - traefik.http.routers.eshop-order-service.middlewares=rate-limit@file
 
 server:
   port: 8082

--- a/eshop-product-service/Dockerfile
+++ b/eshop-product-service/Dockerfile
@@ -2,7 +2,7 @@ FROM amazoncorretto:21-alpine-jdk as build
 WORKDIR /app
 COPY . .
 RUN chmod +x ./gradlew
-RUN --mount=type=cache,target=/root/.gradle ./gradlew build
+RUN --mount=type=cache,target=/root/.gradle ./gradlew build -x test
 
 FROM amazoncorretto:21-alpine
 WORKDIR /app

--- a/eshop-product-service/src/main/resources/application-dev.yaml
+++ b/eshop-product-service/src/main/resources/application-dev.yaml
@@ -25,6 +25,7 @@ spring:
           - traefik.enable=true
           - traefik.http.routers.eshop-product-service.rule=PathPrefix(`/api/v1/products`)
           - traefik.http.services.eshop-product-service.loadbalancer.server.port=8084
+          - traefik.http.routers.eshop-product-service.middlewares=rate-limit@file
 server:
   port: 8084
 

--- a/eshop-user-service/Dockerfile
+++ b/eshop-user-service/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 
 RUN chmod +x ./gradlew
 
-RUN ./gradlew build
+RUN ./gradlew build -x test
 
 FROM amazoncorretto:21-alpine-jdk
 

--- a/eshop-user-service/src/main/resources/application-dev.yaml
+++ b/eshop-user-service/src/main/resources/application-dev.yaml
@@ -29,6 +29,7 @@ spring:
           - traefik.enable=true
           - "traefik.http.routers.eshop-auth-service.rule=PathPrefix(`/api/v1/users`) || PathPrefix(`/oauth2`)"
           - traefik.http.services.eshop-auth-service.loadbalancer.server.port=8088
+          - traefik.http.routers.eshop-auth-service.middlewares=rate-limit@file
         register: true
         prefer-ip-address: true
 eshop:

--- a/infrastructure/docker-compose-dev.yaml
+++ b/infrastructure/docker-compose-dev.yaml
@@ -13,6 +13,7 @@ services:
       - "8080:8080"
     volumes:
       - ./traefik/traefik-dev.yml:/etc/traefik/traefik.yml
+      - ./traefik/dynamic.yml:/etc/traefik/dynamic.yml
       - ./logs:/logs
 
   consul:
@@ -29,7 +30,7 @@ services:
   # --- Databases ---
 
   user-service-db:
-    image: postgres
+    image: postgres:16
     ports:
       - "5432:5432"
     environment:
@@ -40,7 +41,7 @@ services:
       - user_service_db:/var/lib/postgresql/data
 
   order-service-db:
-    image: postgres
+    image: postgres:16
     ports:
       - "5433:5432"
     environment:

--- a/infrastructure/traefik/dynamic.yml
+++ b/infrastructure/traefik/dynamic.yml
@@ -1,0 +1,6 @@
+http:
+  middlewares:
+    rate-limit:
+      rateLimit:
+        average: 100
+        burst: 50

--- a/infrastructure/traefik/traefik-dev.yml
+++ b/infrastructure/traefik/traefik-dev.yml
@@ -11,6 +11,9 @@ providers:
     endpoint:
       address: "consul:8500"
     watch: true
+  file:
+    filename: /etc/traefik/dynamic.yml
+    watch: true
 
 log:
   level: DEBUG


### PR DESCRIPTION
Changes:

- Added documentation for all three services covering overview, tech stack, endpoints, authentication and configuration
- Added Design Decisions section to the main README covering CQRS, Kafka, OAuth2, Consul, Traefik and rate limiting
- Fixed OAuth2 endpoints missing from Consul tags causing Traefik 404 on token requests
- Fixed Docker builds running tests during image build
- Added Traefik rate limiting via token bucket middleware applied to all service routes