### PR TITLE
feat(order-service): Implement transactional outbox pattern (#12)

### DIFF
--- a/docs/adr/001-order-event-publishing-reliability.md
+++ b/docs/adr/001-order-event-publishing-reliability.md
@@ -1,0 +1,69 @@
+# ADR-001: Order Event Publishing Reliability
+
+**Status:** Accepted  
+**Date:** 2026-06-08  
+**Context:** Order service — **OrderCommandService.createOrder**
+
+---
+
+## Context
+
+When an order is created, two things must happen: the order is persisted to Postgres, and an **order-events** Kafka message is published so the inventory service can reserve stock. These are two separate I/O operations with no shared transaction boundary.
+
+The current implementation calls **kafkaTemplate.send()** and discards the returned **CompletableFuture**. If the broker is unreachable, rejects the message, or the JVM crashes after the DB write, the order is committed as **PENDING** with no event ever published. It stays stuck permanently — there is no recovery path.
+
+Two approaches were considered to fix this.
+
+---
+
+## Options Considered
+
+### Option A — Async callback with compensation
+
+Attach a **whenComplete** callback to the send future. If publishing fails, open a new transaction and flip the order status to **FAILED**.
+
+**Pros:**
+- Minimal code change — no new tables or infrastructure
+- Non-blocking — HTTP request returns as soon as the DB write completes
+
+**Cons:**
+- No atomicity. The DB commit happens before the Kafka result is known. Between the commit and the callback firing, the system is in an inconsistent state.
+- JVM crash in that window leaves the order stuck as **PENDING** with no mechanism to detect or recover it.
+- Compensation is best-effort — if the callback itself fails, the order never gets updated.
+- **FAILED** is the wrong terminal state for "we couldn't publish the event." It conflates a transient infrastructure failure with a genuine business failure.
+
+### Option B — Transactional Outbox
+
+Write the event as a row in an **outbox** table inside the same DB transaction as the order save. A separate poller reads unpublished rows and publishes them to Kafka, then marks them as published.
+
+**Pros:**
+- The order save and the outbox write are atomic. If the DB transaction commits, the event is guaranteed to exist. If it rolls back, neither is persisted.
+- Survives JVM crashes — unpublished rows persist in the DB and will be picked up on restart.
+- Kafka availability is fully decoupled from the HTTP write path. An outage delays event delivery but does not affect order creation.
+- Unpublished rows are directly queryable — operational visibility with a simple **SELECT**.
+
+**Cons:**
+- Additional moving parts: a new **outbox** table, a poller process, and published/failed state tracking.
+- Introduces publishing lag proportional to the poller interval.
+- The poller can publish a message and then crash before marking the row as published, so consumers must handle duplicates — which is already required given Kafka's at-least-once delivery guarantee.
+
+---
+
+## Decision
+
+**Transactional Outbox (Option B).**
+
+Option A fixes the visibility problem — failures are no longer silent — but it does not fix the reliability problem. There is still a window where the order is committed and the event is lost, and no mechanism to recover from it automatically. Compensation works when Kafka is temporarily unavailable and recovers quickly, but it provides no guarantee for cases where the failure is persistent or the JVM dies mid-flight.
+
+The outbox pattern eliminates the window entirely. Once the DB transaction commits, the event exists durably and will be delivered regardless of what happens next. This is the only approach that gives a genuine at-least-once delivery guarantee on the publishing side without blocking the HTTP thread on broker availability.
+
+The operational overhead is real but bounded: one new table, one poller (a lightweight scheduled task or Debezium), and a **published** flag. Given the system already depends on Kafka for order correctness, the reliability guarantee is worth the added complexity.
+
+---
+
+## Consequences
+
+- The **order-events** publish lag is no longer zero — it is bounded by the poller interval. For most use cases a sub-second interval is sufficient.
+- Consumers of **order-events** must be idempotent (already required by at-least-once Kafka semantics, and already flagged as a known gap in the resiliency backlog).
+- The **outbox** table acts as an audit log of all events the order service has ever attempted to publish, which is useful for debugging and replay.
+- The relay uses **SELECT FOR UPDATE** to prevent concurrent instances from processing the same rows. **SKIP LOCKED** can be applied as an optimization — instead of waiting for a lock held by another instance, the poller skips locked rows and returns immediately, reducing contention under high polling frequency.

--- a/docs/order-service/README.md
+++ b/docs/order-service/README.md
@@ -29,6 +29,16 @@ Handles order creation and retrieval. Implements the CQRS pattern with PostgreSQ
 
 Validates incoming JWT access tokens locally using the public key fetched from the user service JWK endpoint. No request is made to the user service per request — the key is cached after the first fetch.
 
+## Transactional Outbox
+
+Order events are not published to Kafka directly. Instead, the event is written to an **outbox** table in the same PostgreSQL transaction as the order save. This guarantees that an event is never lost — if the transaction commits, the event exists durably regardless of Kafka availability.
+
+A scheduled relay (**OutboxEventRelay**) polls the **outbox** table every 5 seconds for unpublished rows. For each event it sends the payload to the configured Kafka topic synchronously, then lets Hibernate mark the row as **published = true** on transaction commit. If the Kafka send fails, the row stays unpublished and is retried on the next poll.
+
+The relay uses **SELECT FOR UPDATE** to lock unpublished rows during processing. This prevents multiple service instances from picking up the same event concurrently.
+
+Consumers of **order-events** must be idempotent — the relay provides at-least-once delivery, meaning a message can be published more than once if the relay crashes after the Kafka send but before the transaction commits.
+
 ## Configuration
 
 The following environment variables are required to run the service:

--- a/eshop-order-service/src/main/java/eshop/com/eshoporderservice/EshopOrderServiceApplication.java
+++ b/eshop-order-service/src/main/java/eshop/com/eshoporderservice/EshopOrderServiceApplication.java
@@ -2,7 +2,9 @@ package eshop.com.eshoporderservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class EshopOrderServiceApplication {
 

--- a/eshop-order-service/src/main/java/eshop/com/eshoporderservice/outbox/OutboxEvent.java
+++ b/eshop-order-service/src/main/java/eshop/com/eshoporderservice/outbox/OutboxEvent.java
@@ -1,0 +1,29 @@
+package eshop.com.eshoporderservice.outbox;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@Entity
+@Table(name = "outbox")
+public class OutboxEvent {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false)
+    private String topic;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String payload;
+
+    @Column(nullable = false)
+    private boolean published = false;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+}

--- a/eshop-order-service/src/main/java/eshop/com/eshoporderservice/outbox/OutboxEventRelay.java
+++ b/eshop-order-service/src/main/java/eshop/com/eshoporderservice/outbox/OutboxEventRelay.java
@@ -1,0 +1,33 @@
+package eshop.com.eshoporderservice.outbox;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OutboxEventRelay {
+
+    private final OutboxEventRepository outboxEventRepository;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    @Scheduled(fixedDelay = 5000)
+    @Transactional
+    public void relay() {
+        List<OutboxEvent> events = outboxEventRepository.findUnpublishedForUpdate();
+        for (OutboxEvent event : events) {
+            try {
+                kafkaTemplate.send(event.getTopic(), event.getPayload()).get();
+                event.setPublished(true);
+            } catch (Exception e) {
+                log.error("Failed to publish outbox event {}: {}", event.getId(), e.getMessage());
+            }
+        }
+    }
+}

--- a/eshop-order-service/src/main/java/eshop/com/eshoporderservice/outbox/OutboxEventRepository.java
+++ b/eshop-order-service/src/main/java/eshop/com/eshoporderservice/outbox/OutboxEventRepository.java
@@ -1,11 +1,13 @@
 package eshop.com.eshoporderservice.outbox;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.UUID;
 
 public interface OutboxEventRepository extends JpaRepository<OutboxEvent, UUID> {
 
-    List<OutboxEvent> findByPublishedFalse();
+    @Query(value = "SELECT * FROM outbox WHERE published = false FOR UPDATE", nativeQuery = true)
+    List<OutboxEvent> findUnpublishedForUpdate();
 }

--- a/eshop-order-service/src/main/java/eshop/com/eshoporderservice/outbox/OutboxEventRepository.java
+++ b/eshop-order-service/src/main/java/eshop/com/eshoporderservice/outbox/OutboxEventRepository.java
@@ -1,0 +1,11 @@
+package eshop.com.eshoporderservice.outbox;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface OutboxEventRepository extends JpaRepository<OutboxEvent, UUID> {
+
+    List<OutboxEvent> findByPublishedFalse();
+}

--- a/eshop-order-service/src/main/java/eshop/com/eshoporderservice/service/OrderCommandService.java
+++ b/eshop-order-service/src/main/java/eshop/com/eshoporderservice/service/OrderCommandService.java
@@ -5,25 +5,30 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import eshop.com.eshoporderservice.event.OrderCreatedEvent;
 import eshop.com.eshoporderservice.order.model.OrderCommand;
 import eshop.com.eshoporderservice.order.repository.OrderCommandRepository;
+import eshop.com.eshoporderservice.outbox.OutboxEvent;
+import eshop.com.eshoporderservice.outbox.OutboxEventRepository;
 import eshop.com.eshoporderservice.web.dto.OrderCommandCreateRequest;
-import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
 
 @Service
 public class OrderCommandService {
 
     private final OrderCommandRepository orderCommandRepository;
-    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final OutboxEventRepository outboxEventRepository;
     private final ObjectMapper objectMapper;
 
     public OrderCommandService(OrderCommandRepository orderCommandRepository,
-                               KafkaTemplate<String, String> kafkaTemplate,
+                               OutboxEventRepository outboxEventRepository,
                                ObjectMapper objectMapper) {
         this.orderCommandRepository = orderCommandRepository;
-        this.kafkaTemplate = kafkaTemplate;
+        this.outboxEventRepository = outboxEventRepository;
         this.objectMapper = objectMapper;
     }
 
+    @Transactional
     public OrderCommand createOrder(OrderCommandCreateRequest request) {
         OrderCommand orderCommand = new OrderCommand();
         orderCommand.setProduct(request.getProduct());
@@ -34,9 +39,14 @@ public class OrderCommandService {
 
         try {
             OrderCreatedEvent event = new OrderCreatedEvent(saved.getId(), saved.getProduct(), saved.getQuantity());
-            kafkaTemplate.send("order-events", objectMapper.writeValueAsString(event));
+
+            OutboxEvent outboxEvent = new OutboxEvent();
+            outboxEvent.setTopic("order-events");
+            outboxEvent.setPayload(objectMapper.writeValueAsString(event));
+            outboxEvent.setCreatedAt(LocalDateTime.now());
+            outboxEventRepository.save(outboxEvent);
         } catch (JsonProcessingException e) {
-            throw new RuntimeException("Failed to serialize OrderCreatedEvent", e);
+            throw new RuntimeException("Failed to serialize order event", e);
         }
 
         return saved;

--- a/eshop-order-service/src/test/java/eshop/com/eshoporderservice/outbox/OutboxEventRelayTest.java
+++ b/eshop-order-service/src/test/java/eshop/com/eshoporderservice/outbox/OutboxEventRelayTest.java
@@ -1,0 +1,54 @@
+package eshop.com.eshoporderservice.outbox;
+
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OutboxEventRelayTest {
+
+    @Mock
+    private OutboxEventRepository outboxEventRepository;
+
+    @Mock
+    private KafkaTemplate<String, String> kafkaTemplate;
+
+    @InjectMocks
+    private OutboxEventRelay outboxEventRelay;
+
+    @Test
+    void relay_whenUnpublishedEventsExist_thenSendsEachToKafka() throws Exception {
+        OutboxEvent first = new OutboxEvent();
+        first.setTopic("order-events");
+        first.setPayload("{\"id\":\"1\"}");
+
+        OutboxEvent second = new OutboxEvent();
+        second.setTopic("order-events");
+        second.setPayload("{\"id\":\"2\"}");
+
+        when(outboxEventRepository.findUnpublishedForUpdate()).thenReturn(List.of(first, second));
+        when(kafkaTemplate.send(anyString(), anyString()))
+                .thenReturn(CompletableFuture.completedFuture(mock(SendResult.class)));
+
+        outboxEventRelay.relay();
+
+        verify(kafkaTemplate, times(2)).send(anyString(), anyString());
+        assertThat(first.isPublished()).isTrue();
+        assertThat(second.isPublished()).isTrue();
+    }
+}

--- a/eshop-order-service/src/test/java/eshop/com/eshoporderservice/outbox/OutboxEventRelayTest.java
+++ b/eshop-order-service/src/test/java/eshop/com/eshoporderservice/outbox/OutboxEventRelayTest.java
@@ -51,4 +51,19 @@ class OutboxEventRelayTest {
         assertThat(first.isPublished()).isTrue();
         assertThat(second.isPublished()).isTrue();
     }
+
+    @Test
+    void relay_whenKafkaSendFails_thenEventRemainsUnpublished() throws Exception {
+        OutboxEvent event = new OutboxEvent();
+        event.setTopic("order-events");
+        event.setPayload("{\"id\":\"1\"}");
+
+        when(outboxEventRepository.findUnpublishedForUpdate()).thenReturn(List.of(event));
+        when(kafkaTemplate.send(anyString(), anyString()))
+                .thenReturn(CompletableFuture.failedFuture(new RuntimeException("Kafka unavailable")));
+
+        outboxEventRelay.relay();
+
+        assertThat(event.isPublished()).isFalse();
+    }
 }

--- a/eshop-order-service/src/test/java/eshop/com/eshoporderservice/service/OrderCommandServiceTest.java
+++ b/eshop-order-service/src/test/java/eshop/com/eshoporderservice/service/OrderCommandServiceTest.java
@@ -3,21 +3,21 @@ package eshop.com.eshoporderservice.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eshop.com.eshoporderservice.order.model.OrderCommand;
 import eshop.com.eshoporderservice.order.repository.OrderCommandRepository;
+import eshop.com.eshoporderservice.outbox.OutboxEvent;
+import eshop.com.eshoporderservice.outbox.OutboxEventRepository;
 import eshop.com.eshoporderservice.web.dto.OrderCommandCreateRequest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.kafka.core.KafkaTemplate;
 
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.contains;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -28,7 +28,7 @@ class OrderCommandServiceTest {
     private OrderCommandRepository orderCommandRepository;
 
     @Mock
-    private KafkaTemplate<String, String> kafkaTemplate;
+    private OutboxEventRepository outboxEventRepository;
 
     @Spy
     private ObjectMapper objectMapper;
@@ -57,7 +57,7 @@ class OrderCommandServiceTest {
     }
 
     @Test
-    void createOrder_whenValidRequest_thenPublishesEventToKafka() {
+    void createOrder_whenValidRequest_thenSavesOutboxEventWithOrderId() {
         OrderCommandCreateRequest request = new OrderCommandCreateRequest();
         request.setProduct("Laptop");
         request.setQuantity(1);
@@ -71,6 +71,9 @@ class OrderCommandServiceTest {
 
         orderCommandService.createOrder(request);
 
-        verify(kafkaTemplate).send(eq("order-events"), contains(orderId.toString()));
+        ArgumentCaptor<OutboxEvent> captor = ArgumentCaptor.forClass(OutboxEvent.class);
+        verify(outboxEventRepository).save(captor.capture());
+        assertThat(captor.getValue().getTopic()).isEqualTo("order-events");
+        assertThat(captor.getValue().getPayload()).contains(orderId.toString());
     }
 }


### PR DESCRIPTION
## Summary

- Replaces direct Kafka publish in `OrderCommandService` with an atomic write to an `outbox` table, guaranteeing events are never lost if Kafka is unavailable at order creation time
- Adds `OutboxEventRelay` — a scheduled poller that reads unpublished rows with `SELECT FOR UPDATE`, publishes each to Kafka synchronously, and lets Hibernate mark them as `published = true` on commit; failed events stay unpublished and are retried on the next poll
- Documents the outbox and relay in `docs/order-service/README.md` and adds a `SELECT FOR UPDATE` / `SKIP LOCKED` note to ADR-001