### PR TITLE
feat(ci): Add CI workflows for all services (#13)

### DIFF
--- a/.github/workflows/inventory-service.yml
+++ b/.github/workflows/inventory-service.yml
@@ -1,0 +1,25 @@
+name: Inventory Service
+
+on:
+  push:
+    branches: [dev, main]
+    paths:
+      - 'eshop-inventory-service/**'
+  pull_request:
+    branches: [dev, main]
+    paths:
+      - 'eshop-inventory-service/**'
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: temurin
+      - name: Run tests
+        run: ./gradlew test
+        working-directory: eshop-inventory-service

--- a/.github/workflows/order-service.yml
+++ b/.github/workflows/order-service.yml
@@ -1,0 +1,25 @@
+name: Order Service
+
+on:
+  push:
+    branches: [dev, main]
+    paths:
+      - 'eshop-order-service/**'
+  pull_request:
+    branches: [dev, main]
+    paths:
+      - 'eshop-order-service/**'
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: temurin
+      - name: Run tests
+        run: ./gradlew test
+        working-directory: eshop-order-service

--- a/.github/workflows/product-service.yml
+++ b/.github/workflows/product-service.yml
@@ -1,0 +1,25 @@
+name: Product Service
+
+on:
+  push:
+    branches: [dev, main]
+    paths:
+      - 'eshop-product-service/**'
+  pull_request:
+    branches: [dev, main]
+    paths:
+      - 'eshop-product-service/**'
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: temurin
+      - name: Run tests
+        run: ./gradlew test
+        working-directory: eshop-product-service

--- a/.github/workflows/user-service.yml
+++ b/.github/workflows/user-service.yml
@@ -1,0 +1,25 @@
+name: User Service
+
+on:
+  push:
+    branches: [dev, main]
+    paths:
+      - 'eshop-user-service/**'
+  pull_request:
+    branches: [dev, main]
+    paths:
+      - 'eshop-user-service/**'
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: temurin
+      - name: Run tests
+        run: ./gradlew test
+        working-directory: eshop-user-service


### PR DESCRIPTION
## Summary

- Adds a separate GitHub Actions workflow per service that runs on push and PR to **dev** and **main**
- Each workflow is path-scoped so it only triggers when files within the relevant service directory change
- All workflows run **./gradlew test** on Java 21